### PR TITLE
First implementation of swandaskcluster

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,10 @@
+include LICENSE
+include README.md
+include pyproject.toml
+
+# Patterns to exclude from any directory
+global-exclude *~
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude .git
+global-exclude .ipynb_checkpoints

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
-# swan-daskcluster
-Wrapper of Dask cluster objects to use in SWAN
+# SWAN Dask Cluster
+
+Package to create wrappers of Dask clusters to be used from SWAN.
+
+## Requirements
+
+* dask_lxplus
+* swanportallocator
+
+## Install
+
+```bash
+pip install swandaskcluster
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,51 @@
+"""
+Setup Module for the swandaskcluster package.
+"""
+import os
+
+from jupyter_packaging import get_version
+import setuptools
+
+name="swandaskcluster"
+
+# Get our version
+version = get_version(os.path.join(name, "_version.py"))
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setup_args = dict(
+    name=name,
+    version=version,
+    url="https://github.com/swan-cern/swan-daskcluster",
+    author="SWAN Admins",
+    description="Package to create wrappers of Dask clusters to be used from SWAN",
+    long_description= long_description,
+    long_description_content_type="text/markdown",
+    packages=setuptools.find_packages(),
+    install_requires=[
+        'dask_lxplus',
+        'swanportallocator',
+    ],
+    zip_safe=False,
+    include_package_data=True,
+    python_requires=">=3.6",
+    license="AGPL-3.0",
+    platforms="Linux, Mac OS X, Windows",
+    keywords=["Jupyter", "Notebooks", "SWAN", "CERN"],
+    classifiers=[
+        "License :: OSI Approved :: GNU Affero General Public License v3",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Framework :: Jupyter",
+    ],
+)
+
+
+if __name__ == "__main__":
+    setuptools.setup(**setup_args)

--- a/swandaskcluster/__init__.py
+++ b/swandaskcluster/__init__.py
@@ -1,0 +1,2 @@
+from ._version import __version__
+from .cluster import SwanHTCondorCluster

--- a/swandaskcluster/_version.py
+++ b/swandaskcluster/_version.py
@@ -1,0 +1,3 @@
+# please don't modify this file,
+# this is automatically updated by bump2version
+__version__ = '0.0.0'

--- a/swandaskcluster/cluster.py
+++ b/swandaskcluster/cluster.py
@@ -1,11 +1,17 @@
 
 from . import config
-from .utils import SchedulerConfig
+from .utils import DaskSchedulerConfig, NoPortsException, GeneralException
 
 from dask_lxplus import CernCluster
 
 import dask
 
+
+class SwanDaskClusterException(Exception):
+    '''
+    Generic class for exceptions occurred when creating Dask clusters from SWAN.
+    '''
+    pass
 
 class SwanHTCondorCluster(CernCluster):
     '''
@@ -36,26 +42,39 @@ class SwanHTCondorCluster(CernCluster):
         # TODO: set a value for 'log_directory'
 
         # Scheduler configuration
-        self._scheduler_config = SchedulerConfig()
+        self._scheduler_config = DaskSchedulerConfig()
+        try:
+            port = self._scheduler_config.get_port()
+        except NoPortsException as npe:
+            raise SwanDaskClusterException(
+                'Error when creating a SwanHTCondorCluster: no more clusters '
+                'can be created due to the lack of free ports. Please remove '
+                'one of the existing clusters before creating a new one') \
+            from npe
+        except GeneralException as ge:
+            raise SwanDaskClusterException(
+                'Error when creating a SwanHTCondorCluster: an unknown error '
+                'occurred when trying to obtain a port for the new cluster') \
+            from ge
+
         private_hostname = self._scheduler_config.get_private_hostname()
         contact_hostname = self._scheduler_config.get_contact_hostname()
 
+        scheduler_options['host']            = f'{private_hostname}:{port}'
+        scheduler_options['contact_address'] = f'{contact_hostname}:{port}'
+
         try:
-            port = self._scheduler_config.get_port()
-
-            scheduler_options['host']            = f'{private_hostname}:{port}'
-            scheduler_options['contact_address'] = f'{contact_hostname}:{port}'
-
             super().__init__(worker_image = worker_image,
                              job_extra = { **config_job_extra, **job_extra },
                              scheduler_options = scheduler_options,
                              **base_class_kwargs)
-        except Exception:
-            # Something went wrong.
+        except Exception as e:
+            # Some exception was raised in any of the cluster superclasses.
             # Release the port so that it can be given to other processes and
-            # re-raise
+            # re-raise from the original exception.
             self._scheduler_config.release_port()
-            raise
+            raise SwanDaskClusterException(
+                'Error when creating a SwanHTCondorCluster') from e
 
         # The scheduler was successfully created, we can keep the port
         self._scheduler_config.reserve_port()

--- a/swandaskcluster/cluster.py
+++ b/swandaskcluster/cluster.py
@@ -1,0 +1,61 @@
+
+from . import config
+from .utils import SchedulerConfig
+
+from dask_lxplus import CernCluster
+
+import dask
+
+
+class SwanHTCondorCluster(CernCluster):
+    '''
+    Class that configures an HTCondorCluster to be used from SWAN.
+    '''
+
+    config_name = 'swan'
+
+    def __init__(self,
+                 worker_image = None,
+                 job_extra = {},
+                 scheduler_options = {},
+                 **base_class_kwargs):
+        '''
+        Configures the Dask workers to be used by SWAN clients and dynamically
+        obtains the necessary addresses for a Dask scheduler that runs in a
+        SWAN user session.
+        '''
+
+        # Worker configuration
+        worker_image = worker_image or \
+                       dask.config.get(
+                           f'jobqueue.{self.config_name}.worker-image')
+
+        config_job_extra = dask.config.get(
+                               f'jobqueue.{self.config_name}.job-extra')
+
+        # TODO: set a value for 'log_directory'
+
+        # Scheduler configuration
+        self._scheduler_config = SchedulerConfig()
+        private_hostname = self._scheduler_config.get_private_hostname()
+        contact_hostname = self._scheduler_config.get_contact_hostname()
+
+        try:
+            port = self._scheduler_config.get_port()
+
+            scheduler_options['host']            = f'{private_hostname}:{port}'
+            scheduler_options['contact_address'] = f'{contact_hostname}:{port}'
+
+            super().__init__(worker_image = worker_image,
+                             job_extra = { **config_job_extra, **job_extra },
+                             scheduler_options = scheduler_options,
+                             **base_class_kwargs)
+        except Exception:
+            # Something went wrong.
+            # Release the port so that it can be given to other processes and
+            # re-raise
+            self._scheduler_config.release_port()
+            raise
+
+        # The scheduler was successfully created, we can keep the port
+        self._scheduler_config.reserve_port()

--- a/swandaskcluster/config.py
+++ b/swandaskcluster/config.py
@@ -1,0 +1,12 @@
+import os
+
+import dask
+import yaml
+
+fn = os.path.join(os.path.dirname(__file__), "jobqueue-swan.yaml")
+dask.config.ensure_file(source=fn)
+
+with open(fn) as f:
+    defaults = yaml.safe_load(f)
+
+dask.config.update(dask.config.config, defaults, priority="old")

--- a/swandaskcluster/jobqueue-swan.yaml
+++ b/swandaskcluster/jobqueue-swan.yaml
@@ -1,0 +1,9 @@
+jobqueue:
+  swan:
+    # Use SWAN image as worker image
+    worker-image: '/cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/swan/docker-images/systemuser:v5.15.4'
+
+    # HTCondor job flags
+    job-extra:
+      'getenv': 'True'
+      '+JobFlavour': '"tomorrow"'

--- a/swandaskcluster/utils.py
+++ b/swandaskcluster/utils.py
@@ -1,0 +1,56 @@
+
+import os
+
+from swanportallocator.portallocator import PortAllocatorClient
+
+class SchedulerConfig:
+    '''
+    Helper class that provides information that is relevant for a Dask
+    scheduler running in a SWAN user session, namely:
+    - Private hostname: hostname that resolves to a private address that
+    belongs to Docker's bridge network. The scheduler binds to such address.
+    - Contact hostname: the hostname of the server that hosts the container.
+    Used by the workers to contact the scheduler.
+    - Port: a `PortAllocatorClient` is created to reserve a port for the
+    scheduler to listen on, since it needs to receive connections from the
+    workers.
+    '''
+
+    def __init__(self):
+        '''
+        Initializes a client of the SwanPortAllocator extension.
+        '''
+        self._port_allocator = PortAllocatorClient()
+
+    def get_private_hostname(self):
+        '''
+        Returns the local hostname of the SWAN user session, to which the
+        scheduler will bind.
+        '''
+        return os.environ['HOSTNAME']
+
+    def get_contact_hostname(self):
+        '''
+        Returns the name of the host that runs the SWAN user session container,
+        which will be used by the workers to contact the scheduler.
+        '''
+        return os.environ['SERVER_HOSTNAME']
+
+    def get_port(self):
+        '''
+        Requests and returns a free port for the scheduler to use.
+        '''
+        self._port_allocator.connect()
+        return self._port_allocator.get_ports(1)[0]
+
+    def reserve_port(self):
+        '''
+        Reserves a previously requested port.
+        '''
+        self._port_allocator.set_connected()
+
+    def release_port(self):
+        '''
+        Releases a previously requested port.
+        '''
+        self._port_allocator.set_disconnected()

--- a/swandaskcluster/utils.py
+++ b/swandaskcluster/utils.py
@@ -1,9 +1,10 @@
 
 import os
 
-from swanportallocator.portallocator import PortAllocatorClient
+from swanportallocator.portallocator import PortAllocatorClient, NoPortsException, GeneralException
 
-class SchedulerConfig:
+
+class DaskSchedulerConfig:
     '''
     Helper class that provides information that is relevant for a Dask
     scheduler running in a SWAN user session, namely:
@@ -21,6 +22,7 @@ class SchedulerConfig:
         Initializes a client of the SwanPortAllocator extension.
         '''
         self._port_allocator = PortAllocatorClient()
+        self._port_allocator.connect()
 
     def get_private_hostname(self):
         '''
@@ -40,7 +42,6 @@ class SchedulerConfig:
         '''
         Requests and returns a free port for the scheduler to use.
         '''
-        self._port_allocator.connect()
         return self._port_allocator.get_ports(1)[0]
 
     def reserve_port(self):


### PR DESCRIPTION
First implementation of a wrapper for `CernCluster` that makes use of `SwanPortAllocator` to reserve a port for the Dask scheduler. The private and contact addresses for the scheduler are also obtained dynamically.