### PR TITLE
Generate a PR in systemuser-image when tagging swan-daskcluster

### DIFF
--- a/.github/workflows/swan-ci-ca.yml
+++ b/.github/workflows/swan-ci-ca.yml
@@ -68,3 +68,12 @@ jobs:
         body_path: /tmp/release_body.md
         draft: false
         prerelease: false
+
+    - name: Invoke workflow in systemuser-image
+      uses: benc-uk/workflow-dispatch@v1
+      with:
+        workflow: SWAN CI/CD pipeline
+        ref: master
+        repo: swan-cern/systemuser-image
+        token: ${{ secrets.WORKFLOW_ACCESS_TOKEN }}
+        inputs: '{ "package": "${{env.PACKAGE_NAME}}", "version": "${{env.PACKAGE_VERSION}}" }'


### PR DESCRIPTION
So that the swan-daskcluster version is updated in the Dockerfile of systemuser-image.

Copied from jupyter-extensions, which do the same.