### PR TITLE
Create a default Security object for Dask clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,21 @@ Package to create wrappers of Dask clusters to be used from SWAN.
 ```bash
 pip install swandaskcluster
 ```
+
+## Security
+
+This package provides a
+[security loader](https://docs.dask.org/en/stable/configuration.html#distributed.client.security-loader)
+function to automatically set the appropriate TLS configuration in Dask clients
+created from SWAN.
+
+This makes it possible to create Dask clients in the following way:
+
+```python
+from dask.distributed import Client
+
+client = Client("tls://10.100.244.186:30124")
+```
+
+i.e. with no need to construct and pass a `Security` object as part of the
+`Client` constructor.

--- a/swandaskcluster/cluster.py
+++ b/swandaskcluster/cluster.py
@@ -78,7 +78,7 @@ class SwanHTCondorCluster(CernCluster):
         # TODO: set a value for 'log_directory'
 
         # Security
-        security = self._get_security()
+        security = self.security()
         if security is None:
             raise SwanDaskClusterException(
                 'Error when creating a SwanHTCondorCluster: could not '
@@ -129,7 +129,8 @@ class SwanHTCondorCluster(CernCluster):
         # The scheduler was successfully created, we can keep the port
         self._scheduler_config.reserve_port()
 
-    def _get_security(self):
+    @classmethod
+    def security(cls):
         '''
         Constructs and returns a Dask Security object if a directory with
         pregenerated certificates is found. Otherwise it logs an error and

--- a/swandaskcluster/cluster.py
+++ b/swandaskcluster/cluster.py
@@ -57,7 +57,6 @@ class SwanHTCondorCluster(CernCluster):
     job_cls = SwanHTCondorJob
 
     def __init__(self,
-                 worker_image = None,
                  job_extra = {},
                  scheduler_options = {},
                  **base_class_kwargs):
@@ -68,9 +67,14 @@ class SwanHTCondorCluster(CernCluster):
         '''
 
         # Worker configuration
-        worker_image = worker_image or \
-                       dask.config.get(
+        worker_image = dask.config.get(
                            f'jobqueue.{self.config_name}.worker-image')
+        tag = os.getenv('VERSION_DOCKER_IMAGE', None)
+        if tag is None:
+            raise SwanDaskClusterException(
+                'Error when creating a SwanHTCondorCluster: could not '
+                'find the tag to be used for the worker image')
+        worker_image += f':{tag}'
 
         config_job_extra = dask.config.get(
                                f'jobqueue.{self.config_name}.job-extra')

--- a/swandaskcluster/jobqueue-swan.yaml
+++ b/swandaskcluster/jobqueue-swan.yaml
@@ -1,7 +1,8 @@
 jobqueue:
   swan:
     # Use SWAN image as worker image
-    worker-image: '/cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/swan/docker-images/systemuser:v5.15.4'
+    # The specific tag is added dynamically by SwanHTCondorCluster
+    worker-image: '/cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/swan/docker-images/systemuser'
 
     # HTCondor job flags
     job-extra:

--- a/swandaskcluster/security.py
+++ b/swandaskcluster/security.py
@@ -1,4 +1,16 @@
 from .cluster import SwanHTCondorCluster
 
 def loader(info):
+    '''
+    Implements a default security loader for Dask clients. When a Dask Client
+    object is created, this function will be called and will provide the
+    client with a Security object, which is obtained from SwanHTCondorCluster.
+    Note how the security configuration that the Dask client obtains is the
+    same as the one used by the Dask scheduler.
+
+    To tell Dask to use this function, the following variable is set in the
+    notebook and terminal environments:
+    DASK_DISTRIBUTED__CLIENT__SECURITY_LOADER="swandaskcluster.security.loader"
+    '''
+
     return SwanHTCondorCluster.security()

--- a/swandaskcluster/security.py
+++ b/swandaskcluster/security.py
@@ -1,0 +1,4 @@
+from .cluster import SwanHTCondorCluster
+
+def loader(info):
+    return SwanHTCondorCluster.security()


### PR DESCRIPTION
The purpose of these changes is to make it possible for Dask users to do:

```python
from dask.distributed import Client

client = Client("tls://10.100.244.186:30124")
```
instead of
```python
from dask.distributed import Client

from distributed.security import Security

sec = Security(tls_ca_file='/srv/dask_tls/ca.crt',
               tls_client_cert='/srv/dask_tls/server.crt',
               tls_client_key='/srv/dask_tls/server.key',
               require_encryption=True)

client = Client("tls://10.100.245.78:31965", security=sec)
```
when creating Dask clients in SWAN.

Note that the Dask lab extension generates the first code snippet when doing drag&drop, so this aligns with what the extension provides out of the box and does not require any changes to it (nor any additional typing from the user).