### PR TITLE
Change default Dask worker image to Alma9

### DIFF
--- a/swandaskcluster/jobqueue-swan.yaml
+++ b/swandaskcluster/jobqueue-swan.yaml
@@ -2,7 +2,7 @@ jobqueue:
   swan:
     # Use SWAN image as worker image
     # The specific tag is added dynamically by SwanHTCondorCluster
-    worker-image: '/cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/swan/docker-images/systemuser'
+    worker-image: '/cvmfs/unpacked.cern.ch/gitlab-registry.cern.ch/swan/docker-images/jupyter/swan-cern'
 
     # HTCondor job flags
     job-extra:


### PR DESCRIPTION
Since the goal is to show the AF pilot with Alma9, let's just switch the worker image to Alma9 already.

The PR to include it in unpacked has already been merged: https://gitlab.cern.ch/unpacked/sync/-/merge_requests/244